### PR TITLE
`.env` should not be ignored in template's `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ pnpm-debug.log*
 
 
 # environment variables
-.env
 .env.production
 
 # macOS-specific files


### PR DESCRIPTION
The `.env` file is marked in the `.gitignore`, causing git to ignore the `.env` file during commits, which leads to build failures. 

`.env` file needs to be ignored during development, but since this repository is published as a template, it should be retained. 