### PR TITLE
fix: decode URL parameter in search page

### DIFF
--- a/src/pages/search/[q].astro
+++ b/src/pages/search/[q].astro
@@ -2,7 +2,7 @@
 import List from '../../components/list.astro'
 import { getChannelInfo } from '../../lib/telegram'
 
-const q = Astro.url.searchParams.get('q') || Astro.params.q
+const q = Astro.url.searchParams.get('q') || decodeURIComponent(Astro.params.q || '')
 const channel = await getChannelInfo(Astro, {
   q,
 })


### PR DESCRIPTION
  Fixes tags filtering Issue mentioned in  #120

  ## Problem
  Clicking a tag (e.g. `#tech`) navigates to `/search/%23tech`, but
  the URL-encoded parameter `%23` was not decoded, causing empty search
  results.

  ## Solution
  Added `decodeURIComponent()` to properly decode the URL parameter before
   passing it to the Telegram API.

  ## Changes
  - `src/pages/search/[q].astro`: decode `Astro.params.q` before use

  ## Testing
  I've tested locally with tag searches like `#tech` - results now display
  correctly.